### PR TITLE
Upgrading `ruby-lsp` to pass test cases

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,7 @@ GEM
       sorbet-static (= 0.5.11670)
     sorbet-runtime (0.5.11670)
     sorbet-static (0.5.11670-universal-darwin)
+    sorbet-static (0.5.11670-x86_64-linux)
     sorbet-static-and-runtime (0.5.11670)
       sorbet (= 0.5.11670)
       sorbet-runtime (= 0.5.11670)
@@ -79,6 +80,7 @@ GEM
 PLATFORMS
   arm64-darwin-23
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   minitest (~> 5.16)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     ruby-lsp-rake (0.3.3)
-      ruby-lsp (~> 0.22.1)
+      ruby-lsp (~> 0.23.0)
 
 GEM
   remote: https://rubygems.org/
@@ -40,7 +40,7 @@ GEM
       unicode-display_width (>= 2.4.0, < 4.0)
     rubocop-ast (1.36.2)
       parser (>= 3.3.1.0)
-    ruby-lsp (0.22.1)
+    ruby-lsp (0.23.11)
       language_server-protocol (~> 3.17.0)
       prism (>= 1.2, < 2.0)
       rbs (>= 3, < 4)

--- a/ruby-lsp-rake.gemspec
+++ b/ruby-lsp-rake.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency("ruby-lsp", "~> 0.22.1")
+  spec.add_dependency("ruby-lsp", "~> 0.23.0")
 end


### PR DESCRIPTION
## Abstract

`ruby-lsp@0.22.1` does not supply the method `pop_result`. To fix failed test cases, I upgraded the dependency for`ruby-lsp`.

- Added support for `x86_64` Linux
- Updated `ruby-lsp` dependency to version 0.23.0

I'm using GitHub Codespace to compose this PR :)

## Problems & Causes

The method `pop_result` introduced at the realse of `0.23.0`. So that, ruby interpreter cannot find it while using `ruby-lsp@0.22.1`.

```log
> bundle exec rake
Run options: --seed 54735

# Running:

/usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/call_validation.rb:52: warning: method redefined; discarding old process_message
/usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/_methods.rb:257: warning: previous definition of process_message was here
/usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/call_validation.rb:52: warning: method redefined; discarding old parse!
/usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/_methods.rb:257: warning: previous definition of parse! was here
/usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/call_validation.rb:52: warning: method redefined; discarding old activate
/usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/_methods.rb:257: warning: previous definition of activate was here
/usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/call_validation.rb:52: warning: method redefined; discarding old perform
/usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/_methods.rb:257: warning: previous definition of perform was here
/usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/call_validation.rb:52: warning: method redefined; discarding old response
/usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/_methods.rb:257: warning: previous definition of response was here
/usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/call_validation.rb:52: warning: method redefined; discarding old deactivate
/usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/_methods.rb:257: warning: previous definition of deactivate was here
E/usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/call_validation.rb:52: warning: method redefined; discarding old language_id
/usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/_methods.rb:257: warning: previous definition of language_id was here
EEEEEEE

Finished in 0.093414s, 85.6407 runs/s, 0.0000 assertions/s.

  1) Error:
RubyLsp::Rake::TestDefinition#test_recognizes_rake_tasks:
NoMethodError: undefined method `pop_result' for an instance of RubyLsp::Rake::TestDefinition
    test/ruby_lsp_rake/code_lens_test.rb:40:in `block in generate_code_lens_for_source'
    /usr/local/rvm/gems/ruby-3.3.4/gems/ruby-lsp-0.22.1/lib/ruby_lsp/test_helper.rb:46:in `with_server'
    /usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/call_validation.rb:278:in `bind_call'
    /usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/call_validation.rb:278:in `validate_call'
    /usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/_methods.rb:277:in `block in _on_method_added'
    test/ruby_lsp_rake/code_lens_test.rb:33:in `generate_code_lens_for_source'
    test/ruby_lsp_rake/code_lens_test.rb:11:in `test_recognizes_rake_tasks'

  2) Error:
RubyLsp::Rake::TestDefinition#test_recognizes_task_definition:
NoMethodError: undefined method `pop_result' for an instance of RubyLsp::Rake::TestDefinition
    test/ruby_lsp_rake/definition_test.rb:40:in `block in generate_definitions_for_source'
    /usr/local/rvm/gems/ruby-3.3.4/gems/ruby-lsp-0.22.1/lib/ruby_lsp/test_helper.rb:46:in `with_server'
    /usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/call_validation.rb:278:in `bind_call'
    /usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/call_validation.rb:278:in `validate_call'
    /usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/call_validation.rb:199:in `block in create_validator_slow'
    test/ruby_lsp_rake/definition_test.rb:33:in `generate_definitions_for_source'
    test/ruby_lsp_rake/definition_test.rb:11:in `test_recognizes_task_definition'

  3) Error:
RubyLsp::Rake::TestHover#test_hook_returns_link_to_task_defined_by_symbol:
NoMethodError: undefined method `pop_result' for an instance of RubyLsp::Rake::TestHover
    test/ruby_lsp_rake/hover_test.rb:129:in `block in hover_on_source'
    /usr/local/rvm/gems/ruby-3.3.4/gems/ruby-lsp-0.22.1/lib/ruby_lsp/test_helper.rb:46:in `with_server'
    /usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/call_validation.rb:278:in `bind_call'
    /usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/call_validation.rb:278:in `validate_call'
    /usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/call_validation.rb:199:in `block in create_validator_slow'
    test/ruby_lsp_rake/hover_test.rb:122:in `hover_on_source'
    test/ruby_lsp_rake/hover_test.rb:11:in `test_hook_returns_link_to_task_defined_by_symbol'

  4) Error:
RubyLsp::Rake::TestHover#test_hook_returns_link_to_task_defined_with_desc:
NoMethodError: undefined method `pop_result' for an instance of RubyLsp::Rake::TestHover
    test/ruby_lsp_rake/hover_test.rb:129:in `block in hover_on_source'
    /usr/local/rvm/gems/ruby-3.3.4/gems/ruby-lsp-0.22.1/lib/ruby_lsp/test_helper.rb:46:in `with_server'
    /usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/call_validation.rb:278:in `bind_call'
    /usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/call_validation.rb:278:in `validate_call'
    /usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/call_validation.rb:199:in `block in create_validator_slow'
    test/ruby_lsp_rake/hover_test.rb:122:in `hover_on_source'
    test/ruby_lsp_rake/hover_test.rb:96:in `test_hook_returns_link_to_task_defined_with_desc'

  5) Error:
RubyLsp::Rake::TestHover#test_hook_returns_link_to_task_defined_by_hash_with_string_key:
NoMethodError: undefined method `pop_result' for an instance of RubyLsp::Rake::TestHover
    test/ruby_lsp_rake/hover_test.rb:129:in `block in hover_on_source'
    /usr/local/rvm/gems/ruby-3.3.4/gems/ruby-lsp-0.22.1/lib/ruby_lsp/test_helper.rb:46:in `with_server'
    /usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/call_validation.rb:278:in `bind_call'
    /usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/call_validation.rb:278:in `validate_call'
    /usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/call_validation.rb:199:in `block in create_validator_slow'
    test/ruby_lsp_rake/hover_test.rb:122:in `hover_on_source'
    test/ruby_lsp_rake/hover_test.rb:45:in `test_hook_returns_link_to_task_defined_by_hash_with_string_key'

  6) Error:
RubyLsp::Rake::TestHover#test_hook_returns_link_to_task_defined_by_string:
NoMethodError: undefined method `pop_result' for an instance of RubyLsp::Rake::TestHover
    test/ruby_lsp_rake/hover_test.rb:129:in `block in hover_on_source'
    /usr/local/rvm/gems/ruby-3.3.4/gems/ruby-lsp-0.22.1/lib/ruby_lsp/test_helper.rb:46:in `with_server'
    /usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/call_validation.rb:278:in `bind_call'
    /usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/call_validation.rb:278:in `validate_call'
    /usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/call_validation.rb:199:in `block in create_validator_slow'
    test/ruby_lsp_rake/hover_test.rb:122:in `hover_on_source'
    test/ruby_lsp_rake/hover_test.rb:28:in `test_hook_returns_link_to_task_defined_by_string'

  7) Error:
RubyLsp::Rake::TestHover#test_prerequisite_accepts_symbols:
NoMethodError: undefined method `pop_result' for an instance of RubyLsp::Rake::TestHover
    test/ruby_lsp_rake/hover_test.rb:129:in `block in hover_on_source'
    /usr/local/rvm/gems/ruby-3.3.4/gems/ruby-lsp-0.22.1/lib/ruby_lsp/test_helper.rb:46:in `with_server'
    /usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/call_validation.rb:278:in `bind_call'
    /usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/call_validation.rb:278:in `validate_call'
    /usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/call_validation.rb:199:in `block in create_validator_slow'
    test/ruby_lsp_rake/hover_test.rb:122:in `hover_on_source'
    test/ruby_lsp_rake/hover_test.rb:79:in `test_prerequisite_accepts_symbols'

  8) Error:
RubyLsp::Rake::TestHover#test_hook_returns_link_to_task_defined_by_hash_with_symbol_key:
NoMethodError: undefined method `pop_result' for an instance of RubyLsp::Rake::TestHover
    test/ruby_lsp_rake/hover_test.rb:129:in `block in hover_on_source'
    /usr/local/rvm/gems/ruby-3.3.4/gems/ruby-lsp-0.22.1/lib/ruby_lsp/test_helper.rb:46:in `with_server'
    /usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/call_validation.rb:278:in `bind_call'
    /usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/call_validation.rb:278:in `validate_call'
    /usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/call_validation.rb:199:in `block in create_validator_slow'
    test/ruby_lsp_rake/hover_test.rb:122:in `hover_on_source'
    test/ruby_lsp_rake/hover_test.rb:62:in `test_hook_returns_link_to_task_defined_by_hash_with_symbol_key'

8 runs, 0 assertions, 0 failures, 8 errors, 0 skips
rake aborted!
Command failed with status (1): [/usr/local/rvm/rubies/ruby-3.3.4/bin/ruby -Ilib:test:. -w -e 'require "minitest/autorun"; require "test/ruby_lsp_rake/definition_test.rb"; require "test/ruby_lsp_rake/hover_test.rb"; require "test/ruby_lsp_rake/code_lens_test.rb"; require "test/test_helper.rb"' -- ]
/usr/local/rvm/gems/ruby-3.3.4/gems/minitest-5.25.2/lib/minitest/test_task.rb:172:in `block in define'
/usr/local/rvm/gems/ruby-3.3.4/gems/rake-13.2.1/exe/rake:27:in `<top (required)>'
Tasks: TOP => default => test
(See full trace by running task with --trace)
```

The current `Gemfile.lock` is only compatible with a macOS platform however incompatible with other platforms.

```log
> bundle update ruby-lsp
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies...
Resolving dependencies...
Resolving dependencies...
Could not find gem 'sorbet-static (= 0.5.11670)' with platform 'arm64-darwin-23' in rubygems repository https://rubygems.org/ or installed locally.

The source contains the following gems matching 'sorbet-static (= 0.5.11670)':
  * sorbet-static-0.5.11670-aarch64-linux
  * sorbet-static-0.5.11670-java
  * sorbet-static-0.5.11670-universal-darwin
  * sorbet-static-0.5.11670-x86_64-linux
```

In addition, `ruby-lsp@0.22.1` isn't compatible with the latest `vscode-ruby-lsp`. 

```log
2025-02-18 17:29:45.139 [info] (ruby-lsp-rake) [RuboCop] Initialized RuboCop LSP addon 1.72.2.

2025-02-18 17:29:45.141 [info] (ruby-lsp-rake) Error loading addons:

/usr/local/rvm/gems/ruby-3.3.4/gems/ruby-lsp-0.22.1/lib/ruby_lsp/addon.rb:143:in `depend_on_ruby_lsp!': Add-on is not compatible with this version of the Ruby LSP. Skipping its activation (RubyLsp::Addon::IncompatibleApiError)
	from /usr/local/rvm/gems/ruby-3.3.4/gems/tapioca-0.16.10/lib/ruby_lsp/tapioca/addon.rb:4:in `<top (required)>'
	from /usr/local/rvm/rubies/ruby-3.3.4/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
	from /usr/local/rvm/rubies/ruby-3.3.4/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
	from /usr/local/rvm/gems/ruby-3.3.4/gems/ruby-lsp-0.22.1/lib/ruby_lsp/addon.rb:79:in `block in load_addons'
	from /usr/local/rvm/gems/ruby-3.3.4/gems/ruby-lsp-0.22.1/lib/ruby_lsp/addon.rb:74:in `each'
	from /usr/local/rvm/gems/ruby-3.3.4/gems/ruby-lsp-0.22.1/lib/ruby_lsp/addon.rb:74:in `filter_map'
	from /usr/local/rvm/gems/ruby-3.3.4/gems/ruby-lsp-0.22.1/lib/ruby_lsp/addon.rb:74:in `load_addons'
	from /usr/local/rvm/gems/ruby-3.3.4/gems/ruby-lsp-0.22.1/lib/ruby_lsp/server.rb:159:in `load_addons'
	from /usr/local/rvm/gems/ruby-3.3.4/gems/ruby-lsp-0.22.1/lib/ruby_lsp/server.rb:338:in `run_initialized'
	from /usr/local/rvm/gems/ruby-3.3.4/gems/ruby-lsp-0.22.1/lib/ruby_lsp/server.rb:21:in `process_message'
	from /usr/local/rvm/gems/ruby-3.3.4/gems/ruby-lsp-0.22.1/lib/ruby_lsp/base_server.rb:95:in `block in start'
	from /usr/local/rvm/gems/ruby-3.3.4/gems/language_server-protocol-3.17.0.4/lib/language_server/protocol/transport/io/reader.rb:20:in `read'
	from /usr/local/rvm/gems/ruby-3.3.4/gems/ruby-lsp-0.22.1/lib/ruby_lsp/base_server.rb:47:in `start'
	from /usr/local/rvm/gems/ruby-3.3.4/gems/ruby-lsp-0.22.1/exe/ruby-lsp:153:in `<top (required)>'
	from /usr/local/rvm/gems/ruby-3.3.4/bin/ruby-lsp:25:in `load'
	from /usr/local/rvm/gems/ruby-3.3.4/bin/ruby-lsp:25:in `<main>'
	from /usr/local/rvm/gems/ruby-3.3.4/bin/ruby_executable_hooks:22:in `eval'
	from /usr/local/rvm/gems/ruby-3.3.4/bin/ruby_executable_hooks:22:in `<main>'

2025-02-18 17:29:45.142 [info] (ruby-lsp-rake) Error processing initialized: /usr/local/rvm/gems/ruby-3.3.4/gems/ruby-lsp-0.22.1/lib/ruby_lsp/server.rb:345:in `rescue in run_initialized': uninitialized constant RubyLsp::RuboCop::Error (NameError)

          rescue RuboCop::Error => e
                        ^^^^^^^
Did you mean?  IOError
               Errno
	from /usr/local/rvm/gems/ruby-3.3.4/gems/ruby-lsp-0.22.1/lib/ruby_lsp/server.rb:343:in `run_initialized'
	from /usr/local/rvm/gems/ruby-3.3.4/gems/ruby-lsp-0.22.1/lib/ruby_lsp/server.rb:21:in `process_message'
	from /usr/local/rvm/gems/ruby-3.3.4/gems/ruby-lsp-0.22.1/lib/ruby_lsp/base_server.rb:95:in `block in start'
	from /usr/local/rvm/gems/ruby-3.3.4/gems/language_server-protocol-3.17.0.4/lib/language_server/protocol/transport/io/reader.rb:20:in `read'
	from /usr/local/rvm/gems/ruby-3.3.4/gems/ruby-lsp-0.22.1/lib/ruby_lsp/base_server.rb:47:in `start'
	from /usr/local/rvm/gems/ruby-3.3.4/gems/ruby-lsp-0.22.1/exe/ruby-lsp:153:in `<top (required)>'
	from /usr/local/rvm/gems/ruby-3.3.4/bin/ruby-lsp:25:in `load'
	from /usr/local/rvm/gems/ruby-3.3.4/bin/ruby-lsp:25:in `<main>'
	from /usr/local/rvm/gems/ruby-3.3.4/bin/ruby_executable_hooks:22:in `eval'
	from /usr/local/rvm/gems/ruby-3.3.4/bin/ruby_executable_hooks:22:in `<main>'
/usr/local/rvm/gems/ruby-3.3.4/gems/ruby-lsp-0.22.1/lib/ruby_lsp/requests/support/rubocop_runner.rb:88:in `initialize': uninitialized constant RubyLsp::RuboCop::Cop (NameError)

          @offenses = T.let([], T::Array[RuboCop::Cop::Offense])
                                                ^^^^^
Did you mean?  RubyLsp::Scope
	from /usr/local/rvm/gems/ruby-3.3.4/gems/ruby-lsp-0.22.1/lib/ruby_lsp/requests/support/rubocop_formatter.rb:17:in `new'
	from /usr/local/rvm/gems/ruby-3.3.4/gems/ruby-lsp-0.22.1/lib/ruby_lsp/requests/support/rubocop_formatter.rb:17:in `initialize'
	from /usr/local/rvm/gems/ruby-3.3.4/gems/ruby-lsp-0.22.1/lib/ruby_lsp/server.rb:344:in `new'
	from /usr/local/rvm/gems/ruby-3.3.4/gems/ruby-lsp-0.22.1/lib/ruby_lsp/server.rb:344:in `run_initialized'
	from /usr/local/rvm/gems/ruby-3.3.4/gems/ruby-lsp-0.22.1/lib/ruby_lsp/server.rb:21:in `process_message'
	from /usr/local/rvm/gems/ruby-3.3.4/gems/ruby-lsp-0.22.1/lib/ruby_lsp/base_server.rb:95:in `block in start'
	from /usr/local/rvm/gems/ruby-3.3.4/gems/language_server-protocol-3.17.0.4/lib/language_server/protocol/transport/io/reader.rb:20:in `read'
	from /usr/local/rvm/gems/ruby-3.3.4/gems/ruby-lsp-0.22.1/lib/ruby_lsp/base_server.rb:47:in `start'
	from /usr/local/rvm/gems/ruby-3.3.4/gems/ruby-lsp-0.22.1/exe/ruby-lsp:153:in `<top (required)>'
	from /usr/local/rvm/gems/ruby-3.3.4/bin/ruby-lsp:25:in `load'
	from /usr/local/rvm/gems/ruby-3.3.4/bin/ruby-lsp:25:in `<main>'
	from /usr/local/rvm/gems/ruby-3.3.4/bin/ruby_executable_hooks:22:in `eval'
	from /usr/local/rvm/gems/ruby-3.3.4/bin/ruby_executable_hooks:22:in `<main>'
```

## NOTE

I tested the code in a codespace::

```log
> bundle exec rake
Run options: --seed 63493

# Running:

/usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/call_validation.rb:52: warning: method redefined; discarding old process_message
/usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/_methods.rb:257: warning: previous definition of process_message was here
/usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/call_validation.rb:52: warning: method redefined; discarding old parse!
/usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/_methods.rb:257: warning: previous definition of parse! was here
/usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/call_validation.rb:52: warning: method redefined; discarding old activate
/usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/_methods.rb:257: warning: previous definition of activate was here
/usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/call_validation.rb:52: warning: method redefined; discarding old perform
/usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/_methods.rb:257: warning: previous definition of perform was here
/usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/call_validation.rb:52: warning: method redefined; discarding old response
/usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/_methods.rb:257: warning: previous definition of response was here
/usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/call_validation.rb:52: warning: method redefined; discarding old deactivate
/usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/_methods.rb:257: warning: previous definition of deactivate was here
./usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/call_validation.rb:52: warning: method redefined; discarding old language_id
/usr/local/rvm/gems/ruby-3.3.4/gems/sorbet-runtime-0.5.11670/lib/types/private/methods/_methods.rb:257: warning: previous definition of language_id was here
.......

Finished in 0.067164s, 119.1111 runs/s, 253.1112 assertions/s.

8 runs, 17 assertions, 0 failures, 0 errors, 0 skips
Running RuboCop...
Inspecting 17 files
.................

17 files inspected, no offenses detected

Tip: Based on detected gems, the following RuboCop extension libraries might be helpful:
  * rubocop-minitest (https://rubygems.org/gems/rubocop-minitest)
  * rubocop-rake (https://rubygems.org/gems/rubocop-rake)

You can opt out of this message by adding the following to your config (see https://docs.rubocop.org/rubocop/extensions.html#extension-suggestions for more options):
  AllCops:
    SuggestExtensions: false
bundle exec srb tc
No errors! Great job.
```
